### PR TITLE
ConsoleLogger constructor fix

### DIFF
--- a/include/configcat/consolelogger.h
+++ b/include/configcat/consolelogger.h
@@ -7,6 +7,8 @@ namespace configcat {
 
 class ConsoleLogger : public ILogger {
 public:
+    ConsoleLogger(LogLevel logLevel = LOG_LEVEL_WARNING): ILogger(logLevel) {}
+
     void log(LogLevel level, const std::string& message) override {
         printf("[%s]: %s\n", logLevelAsString(level), message.c_str());
     }

--- a/src/version.h
+++ b/src/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define CONFIGCAT_VERSION "2.0.0"
+#define CONFIGCAT_VERSION "2.0.1"


### PR DESCRIPTION
### Describe the purpose of your pull request

- Add a constructor to `ConsoleLogger` to be able to init with different loglevels.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
