### PR TITLE
Custom network adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,13 @@ include(FetchContent)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
+option(CONFIGCAT_USE_EXTERNAL_NETWORK_ADAPTER "Use external network adapter." OFF)
 option(CONFIGCAT_BUILD_TESTS "Build ConfigCat unittests." ON)
 
-find_package(CURL REQUIRED)
+if(NOT CONFIGCAT_USE_EXTERNAL_NETWORK_ADAPTER)
+    find_package(CURL REQUIRED)
+endif()
+
 find_package(nlohmann_json REQUIRED)
 find_package(unofficial-hash-library REQUIRED)
 find_package(semver REQUIRED)
@@ -62,7 +66,12 @@ file(GLOB SOURCES "src/*")
 add_library(configcat ${SOURCES})
 add_library(configcat::configcat ALIAS configcat)
 
-set(CONFIGCAT_LIBRARIES ${CONFIGCAT_LIBRARIES} CURL::libcurl nlohmann_json::nlohmann_json unofficial::hash-library semver::semver)
+if(NOT CONFIGCAT_USE_EXTERNAL_NETWORK_ADAPTER)
+    set(CONFIGCAT_LIBRARIES ${CONFIGCAT_LIBRARIES} CURL::libcurl nlohmann_json::nlohmann_json unofficial::hash-library semver::semver)
+else()
+    set(CONFIGCAT_LIBRARIES ${CONFIGCAT_LIBRARIES} nlohmann_json::nlohmann_json unofficial::hash-library semver::semver)
+    target_compile_definitions(configcat PRIVATE CONFIGCAT_EXTERNAL_NETWORK_ADAPTER_ENABLED)
+endif()
 
 target_link_libraries(configcat
     PRIVATE ${CONFIGCAT_LIBRARIES}

--- a/cmake/configcat-config.cmake.in
+++ b/cmake/configcat-config.cmake.in
@@ -1,7 +1,9 @@
 include(CMakeFindDependencyMacro)
 @PACKAGE_INIT@
 
-find_package(CURL REQUIRED)
+if(NOT CONFIGCAT_USE_EXTERNAL_NETWORK_ADAPTER)
+    find_package(CURL REQUIRED)
+endif()
 find_package(nlohmann_json REQUIRED)
 find_package(unofficial-hash-library REQUIRED)
 find_package(semver REQUIRED)

--- a/include/configcat/httpsessionadapter.h
+++ b/include/configcat/httpsessionadapter.h
@@ -2,18 +2,32 @@
 
 #include <string>
 #include <map>
+#include "proxyauthentication.h"
 
 namespace configcat {
 
 struct Response {
-    long status_code = 0;
+    long statusCode = 0;
     std::string text;
     std::map<std::string, std::string> header;
+
+    bool operationTimedOut = false;
+    std::string error;
+};
+
+class HttpSessionAdapterListener {
+public:
+    virtual bool isClosed() const = 0;
+    virtual ~HttpSessionAdapterListener() = default;
 };
 
 class HttpSessionAdapter {
 public:
-    virtual Response get(const std::string& url, const std::map<std::string, std::string>& header) = 0;
+    virtual bool init(const HttpSessionAdapterListener* sessionAdapterListener, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) = 0;
+    virtual Response get(const std::string& url,
+                         const std::map<std::string, std::string>& header,
+                         const std::map<std::string, std::string>& proxies,
+                         const std::map<std::string, ProxyAuthentication>& proxyAuthentications) = 0;
     virtual void close() = 0;
     virtual ~HttpSessionAdapter() = default;
 };

--- a/include/configcat/httpsessionadapter.h
+++ b/include/configcat/httpsessionadapter.h
@@ -15,15 +15,15 @@ struct Response {
     std::string error;
 };
 
-class HttpSessionAdapterListener {
+class HttpSessionObserver {
 public:
     virtual bool isClosed() const = 0;
-    virtual ~HttpSessionAdapterListener() = default;
+    virtual ~HttpSessionObserver() = default;
 };
 
 class HttpSessionAdapter {
 public:
-    virtual bool init(const HttpSessionAdapterListener* sessionAdapterListener, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) = 0;
+    virtual bool init(const HttpSessionObserver* httpSessionObserver, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) = 0;
     virtual Response get(const std::string& url,
                          const std::map<std::string, std::string>& header,
                          const std::map<std::string, std::string>& proxies,

--- a/include/configcat/httpsessionadapter.h
+++ b/include/configcat/httpsessionadapter.h
@@ -15,15 +15,9 @@ struct Response {
     std::string error;
 };
 
-class HttpSessionObserver {
-public:
-    virtual bool isClosed() const = 0;
-    virtual ~HttpSessionObserver() = default;
-};
-
 class HttpSessionAdapter {
 public:
-    virtual bool init(const HttpSessionObserver* httpSessionObserver, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) = 0;
+    virtual bool init(uint32_t connectTimeoutMs, uint32_t readTimeoutMs) = 0;
     virtual Response get(const std::string& url,
                          const std::map<std::string, std::string>& header,
                          const std::map<std::string, std::string>& proxies,

--- a/src/configfetcher.cpp
+++ b/src/configfetcher.cpp
@@ -1,5 +1,6 @@
-#include "configfetcher.h"
+#include <assert.h>
 
+#include "configfetcher.h"
 #include "configcat/log.h"
 #include "configcat/configcatoptions.h"
 #include "configcat/configcatlogger.h"
@@ -35,7 +36,7 @@ ConfigFetcher::ConfigFetcher(const string& sdkKey, shared_ptr<ConfigCatLogger> l
     }
 #endif
 
-    if (!httpSessionAdapter || !httpSessionAdapter->init(this, connectTimeoutMs, readTimeoutMs)) {
+    if (!httpSessionAdapter || !httpSessionAdapter->init(connectTimeoutMs, readTimeoutMs)) {
         LOG_ERROR(0) << "Cannot initialize httpSessionAdapter.";
         assert(false);
     }
@@ -48,7 +49,6 @@ void ConfigFetcher::close() {
     if (httpSessionAdapter) {
         httpSessionAdapter->close();
     }
-    closed = true;
 }
 
 FetchResponse ConfigFetcher::fetchConfiguration(const std::string& eTag) {

--- a/src/configfetcher.cpp
+++ b/src/configfetcher.cpp
@@ -1,9 +1,9 @@
 #include "configfetcher.h"
 
 #include "configcat/log.h"
-#include "configcat/httpsessionadapter.h"
 #include "configcat/configcatoptions.h"
 #include "configcat/configcatlogger.h"
+#include "curlnetworkadapter.h"
 #include "version.h"
 #include "platform.h"
 #include "utils.h"
@@ -11,47 +11,6 @@
 using namespace std;
 
 namespace configcat {
-
-class LibCurlResourceGuard {
-private:
-    static std::shared_ptr<LibCurlResourceGuard> instance;
-    static std::mutex mutex;
-
-    LibCurlResourceGuard() {
-        curl_global_init(CURL_GLOBAL_DEFAULT);
-    }
-
-    struct Deleter {
-        void operator()(LibCurlResourceGuard* libCurlResourceGuard) {
-            curl_global_cleanup();
-            delete libCurlResourceGuard;
-            LibCurlResourceGuard::instance.reset();
-        }
-    };
-
-public:
-    // Prevent copying
-    LibCurlResourceGuard(const LibCurlResourceGuard&) = delete;
-    LibCurlResourceGuard& operator=(const LibCurlResourceGuard&) = delete;
-
-    static std::shared_ptr<LibCurlResourceGuard> getInstance() {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!instance) {
-            instance = std::shared_ptr<LibCurlResourceGuard>(new LibCurlResourceGuard(), Deleter());
-        }
-        return instance;
-    }
-};
-std::shared_ptr<LibCurlResourceGuard> LibCurlResourceGuard::instance = nullptr;
-std::mutex LibCurlResourceGuard::mutex;
-
-int ProgressCallback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
-    return static_cast<ConfigFetcher*>(clientp)->ProgressFunction(dltotal, dlnow, ultotal, ulnow);
-}
-
-int ConfigFetcher::ProgressFunction(curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
-    return closed ? 1 : 0;  // Return 0 to continue, or 1 to abort
-}
 
 ConfigFetcher::ConfigFetcher(const string& sdkKey, shared_ptr<ConfigCatLogger> logger, const string& mode, const ConfigCatOptions& options):
     sdkKey(sdkKey),
@@ -70,27 +29,19 @@ ConfigFetcher::ConfigFetcher(const string& sdkKey, shared_ptr<ConfigCatLogger> l
             : kEuOnlyBaseUrl;
     userAgent = string("ConfigCat-Cpp/") + mode + "-" + CONFIGCAT_VERSION;
 
-    libCurlResourceGuard = LibCurlResourceGuard::getInstance();
-    curl = curl_easy_init();
-    if (!curl) {
-        LOG_ERROR(0) << "Cannot initialize CURL.";
-        return;
+#ifndef CONFIGCAT_EXTERNAL_NETWORK_ADAPTER_ENABLED
+    if (!httpSessionAdapter) {
+        httpSessionAdapter = make_shared<CurlNetworkAdapter>();
     }
+#endif
 
-    // Timeout setup
-    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, connectTimeoutMs);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, readTimeoutMs);
-
-    // Enable the progress callback function to be able to abort the request
-    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, ProgressCallback);
-    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, this);
+    if (!httpSessionAdapter || !httpSessionAdapter->init(this, connectTimeoutMs, readTimeoutMs)) {
+        LOG_ERROR(0) << "Cannot initialize httpSessionAdapter.";
+        assert(false);
+    }
 }
 
 ConfigFetcher::~ConfigFetcher() {
-    if (curl) {
-        curl_easy_cleanup(curl);
-    }
 }
 
 void ConfigFetcher::close() {
@@ -147,122 +98,48 @@ FetchResponse ConfigFetcher::executeFetch(const std::string& eTag, int executeCo
     return response;
 }
 
-static size_t WriteCallback(void *contents, size_t size, size_t nmemb, std::string *userp) {
-    userp->append((char*)contents, size * nmemb);
-    return size * nmemb;
-}
-
-std::map<std::string, std::string> ParseHeader(const std::string& headerString) {
-    std::map<std::string, std::string> header;
-
-    std::vector<std::string> lines;
-    std::istringstream stream(headerString);
-    std::string line;
-    while (std::getline(stream, line, '\n')) {
-        lines.push_back(line);
-    }
-
-    for (std::string& line : lines) {
-        if (line.length() > 0) {
-            const size_t colonIndex = line.find(':');
-            if (colonIndex != std::string::npos) {
-                std::string value = line.substr(colonIndex + 1);
-                value.erase(0, value.find_first_not_of("\t "));
-                value.resize(std::min<size_t>(value.size(), value.find_last_not_of("\t\n\r ") + 1));
-                header[line.substr(0, colonIndex)] = value;
-            }
-        }
-    }
-
-    return header;
-}
-
 FetchResponse ConfigFetcher::fetch(const std::string& eTag) {
-    string requestUrl(url + "/configuration-files/" + sdkKey + "/" + kConfigJsonName);
-    std::map<std::string, std::string> responseHeaders;
-    std::string readBuffer;
-    long response_code = 0;
-
     if (!httpSessionAdapter) {
-        if (!curl) {
-            LogEntry logEntry = LogEntry(logger, LOG_LEVEL_ERROR, 1103) <<
-                "Unexpected error occurred while trying to fetch config JSON: CURL is not initialized.";
-            return FetchResponse(failure, ConfigEntry::empty, logEntry.getMessage(), true);
-        }
-
-        CURLcode res;
-        std::string headerString;
-
-        // Update header
-        struct curl_slist* headers = NULL;
-        headers = curl_slist_append(headers, (string(kUserAgentHeaderName) + ": " + userAgent).c_str());
-        headers = curl_slist_append(headers, (string(kPlatformHeaderName) + ": " + getPlatformName()).c_str());
-        if (!eTag.empty()) {
-            headers = curl_slist_append(headers, (string(kIfNoneMatchHeaderName) + ": " + eTag).c_str());
-        }
-
-        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-        curl_easy_setopt(curl, CURLOPT_URL, requestUrl.c_str());
-
-        // Set the callback function to receive the response
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
-        curl_easy_setopt(curl, CURLOPT_HEADERDATA, &headerString);
-
-        // Proxy setup
-        const std::string protocol = url.substr(0, url.find(':'));
-        if (proxies.count(protocol) > 0) {
-            curl_easy_setopt(curl, CURLOPT_PROXY, proxies[protocol].c_str());
-            if (proxyAuthentications.count(protocol) > 0) {
-                curl_easy_setopt(curl, CURLOPT_PROXYUSERNAME, proxyAuthentications[protocol].user.c_str());
-                curl_easy_setopt(curl, CURLOPT_PROXYPASSWORD, proxyAuthentications[protocol].password.c_str());
-            }
-        }
-
-        // Perform the request
-        res = curl_easy_perform(curl);
-
-        if (res != CURLE_OK) {
-            LogEntry logEntry = (res == CURLE_OPERATION_TIMEDOUT)
-                                ? LogEntry(logger, LOG_LEVEL_ERROR, 1102) <<
-                                    "Request timed out while trying to fetch config JSON. "
-                                    "Timeout values: [connect: " << connectTimeoutMs << "ms, read: " << readTimeoutMs << "ms]"
-                                : LogEntry(logger, LOG_LEVEL_ERROR, 1103) <<
-                                    "Unexpected error occurred while trying to fetch config JSON: " << curl_easy_strerror(res);
-
-            return FetchResponse(failure, ConfigEntry::empty, logEntry.getMessage(), true);
-        }
-
-        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-
-        // Parse the headers from headerString
-        responseHeaders = ParseHeader(headerString);
-    } else {
-        std::map<std::string, std::string> requestHeader = {
-            {kUserAgentHeaderName, userAgent},
-            {kPlatformHeaderName, getPlatformName()}
-        };
-        if (!eTag.empty()) {
-            requestHeader.insert({kIfNoneMatchHeaderName, eTag});
-        }
-        auto response = httpSessionAdapter->get(requestUrl, requestHeader);
-        response_code = response.status_code;
-        readBuffer = response.text;
-        responseHeaders = response.header;
+        auto error = "HttpSessionAdapter is not provided.";
+        LOG_ERROR(0) << error;
+        assert(false);
+        return FetchResponse(failure, ConfigEntry::empty, error, true);
     }
 
-    switch (response_code) {
+    string requestUrl(url + "/configuration-files/" + sdkKey + "/" + kConfigJsonName);
+    std::map<std::string, std::string> requestHeader = {
+        {kUserAgentHeaderName, userAgent},
+        {kPlatformHeaderName, getPlatformName()}
+    };
+    if (!eTag.empty()) {
+        requestHeader.insert({kIfNoneMatchHeaderName, eTag});
+    }
+
+    auto response = httpSessionAdapter->get(requestUrl, requestHeader, proxies, proxyAuthentications);
+    if (response.operationTimedOut) {
+        LogEntry logEntry = LogEntry(logger, LOG_LEVEL_ERROR, 1102);
+        logEntry << "Request timed out while trying to fetch config JSON. "
+                    "Timeout values: [connect: " << connectTimeoutMs << "ms, read: " << readTimeoutMs << "ms]";
+        return FetchResponse(failure, ConfigEntry::empty, logEntry.getMessage(), true);
+    }
+    if (response.error.length() > 0) {
+        LogEntry logEntry(logger, LOG_LEVEL_ERROR, 1103);
+        logEntry << "Unexpected error occurred while trying to fetch config JSON: " << response.error;
+        return FetchResponse(failure, ConfigEntry::empty, logEntry.getMessage(), true);
+    }
+
+    switch (response.statusCode) {
         case 200:
         case 201:
         case 202:
         case 203:
         case 204: {
-            const auto it = responseHeaders.find(kEtagHeaderName);
-            string eTag = it != responseHeaders.end() ? it->second : "";
+            const auto it = response.header.find(kEtagHeaderName);
+            string eTag = it != response.header.end() ? it->second : "";
             try {
-                auto config = Config::fromJson(readBuffer);
+                auto config = Config::fromJson(response.text);
                 LOG_DEBUG << "Fetch was successful: new config fetched.";
-                return FetchResponse(fetched, make_shared<ConfigEntry>(config, eTag, readBuffer, getUtcNowSecondsSinceEpoch()));
+                return FetchResponse(fetched, make_shared<ConfigEntry>(config, eTag, response.text, getUtcNowSecondsSinceEpoch()));
             } catch (exception& exception) {
                 LogEntry logEntry(logger, LOG_LEVEL_ERROR, 1105);
                 logEntry <<
@@ -281,13 +158,13 @@ FetchResponse ConfigFetcher::fetch(const std::string& eTag) {
             LogEntry logEntry(logger, LOG_LEVEL_ERROR, 1100);
             logEntry <<
                 "Your SDK Key seems to be wrong. You can find the valid SDK Key at https://app.configcat.com/sdkkey. "
-                "Received unexpected response: " << response_code;
+                "Received unexpected response: " << response.statusCode;
             return FetchResponse(failure, ConfigEntry::empty, logEntry.getMessage(), false);
         }
 
         default: {
             LogEntry logEntry(logger, LOG_LEVEL_ERROR, 1101);
-            logEntry << "Unexpected HTTP response was received while trying to fetch config JSON: " << response_code;
+            logEntry << "Unexpected HTTP response was received while trying to fetch config JSON: " << response.statusCode;
             return FetchResponse(failure, ConfigEntry::empty, logEntry.getMessage(), true);
         }
     }

--- a/src/configfetcher.h
+++ b/src/configfetcher.h
@@ -46,7 +46,7 @@ struct FetchResponse {
     }
 };
 
-class ConfigFetcher : public HttpSessionAdapterListener {
+class ConfigFetcher : public HttpSessionObserver {
 public:
     static constexpr char kConfigJsonName[] = "config_v5.json";
     static constexpr char kGlobalBaseUrl[] = "https://cdn-global.configcat.com";

--- a/src/configfetcher.h
+++ b/src/configfetcher.h
@@ -6,13 +6,13 @@
 #include <atomic>
 
 #include "configcat/proxyauthentication.h"
-#include "configcat/httpsessionadapter.h"
 
 namespace configcat {
 
 struct ConfigCatOptions;
 class ConfigCatLogger;
 struct ConfigEntry;
+class HttpSessionAdapter;
 
 enum Status {
     fetched,
@@ -46,7 +46,7 @@ struct FetchResponse {
     }
 };
 
-class ConfigFetcher : public HttpSessionObserver {
+class ConfigFetcher {
 public:
     static constexpr char kConfigJsonName[] = "config_v5.json";
     static constexpr char kGlobalBaseUrl[] = "https://cdn-global.configcat.com";
@@ -64,8 +64,6 @@ public:
     // Fetches the current ConfigCat configuration json.
     FetchResponse fetchConfiguration(const std::string& eTag = "");
 
-    bool isClosed() const override { return closed; }
-
 private:
     FetchResponse executeFetch(const std::string& eTag, int executeCount);
     FetchResponse fetch(const std::string& eTag);
@@ -81,7 +79,6 @@ private:
     bool urlIsCustom = false;
     std::string url;
     std::string userAgent;
-    std::atomic<bool> closed = false;
 };
 
 } // namespace configcat

--- a/src/curlnetworkadapter.cpp
+++ b/src/curlnetworkadapter.cpp
@@ -1,0 +1,169 @@
+#ifndef CONFIGCAT_EXTERNAL_NETWORK_ADAPTER_ENABLED
+
+#include "curlnetworkadapter.h"
+#include <mutex>
+#include <sstream>
+
+namespace configcat {
+
+class LibCurlResourceGuard {
+private:
+    static std::shared_ptr<LibCurlResourceGuard> instance;
+    static std::mutex mutex;
+
+    LibCurlResourceGuard() {
+        curl_global_init(CURL_GLOBAL_DEFAULT);
+    }
+
+    struct Deleter {
+        void operator()(LibCurlResourceGuard* libCurlResourceGuard) {
+            curl_global_cleanup();
+            delete libCurlResourceGuard;
+            LibCurlResourceGuard::instance.reset();
+        }
+    };
+
+public:
+    // Prevent copying
+    LibCurlResourceGuard(const LibCurlResourceGuard&) = delete;
+    LibCurlResourceGuard& operator=(const LibCurlResourceGuard&) = delete;
+
+    static std::shared_ptr<LibCurlResourceGuard> getInstance() {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (!instance) {
+            instance = std::shared_ptr<LibCurlResourceGuard>(new LibCurlResourceGuard(), Deleter());
+        }
+        return instance;
+    }
+};
+std::shared_ptr<LibCurlResourceGuard> LibCurlResourceGuard::instance = nullptr;
+std::mutex LibCurlResourceGuard::mutex;
+
+int ProgressCallback(void* clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
+    return static_cast<CurlNetworkAdapter*>(clientp)->ProgressFunction(dltotal, dlnow, ultotal, ulnow);
+}
+
+int CurlNetworkAdapter::ProgressFunction(curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
+    if (listener) {
+        return listener->isClosed() ? 1 : 0;  // Return 0 to continue, or 1 to abort
+    }
+
+    return 0;
+}
+
+static size_t WriteCallback(void *contents, size_t size, size_t nmemb, std::string *userp) {
+    userp->append((char*)contents, size * nmemb);
+    return size * nmemb;
+}
+
+std::map<std::string, std::string> ParseHeader(const std::string& headerString) {
+    std::map<std::string, std::string> header;
+
+    std::vector<std::string> lines;
+    std::istringstream stream(headerString);
+    std::string line;
+    while (std::getline(stream, line, '\n')) {
+        lines.push_back(line);
+    }
+
+    for (std::string& line : lines) {
+        if (line.length() > 0) {
+            const size_t colonIndex = line.find(':');
+            if (colonIndex != std::string::npos) {
+                std::string value = line.substr(colonIndex + 1);
+                value.erase(0, value.find_first_not_of("\t "));
+                value.resize(std::min<size_t>(value.size(), value.find_last_not_of("\t\n\r ") + 1));
+                header[line.substr(0, colonIndex)] = value;
+            }
+        }
+    }
+
+    return header;
+}
+
+bool CurlNetworkAdapter::init(const HttpSessionAdapterListener* sessionAdapterListener, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) {
+    listener = sessionAdapterListener;
+    libCurlResourceGuard = LibCurlResourceGuard::getInstance();
+    curl = curl_easy_init();
+    if (!curl) {
+        return false;
+    }
+
+    // Timeout setup
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, connectTimeoutMs);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, readTimeoutMs);
+
+    // Enable the progress callback function to be able to abort the request
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, ProgressCallback);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, this);
+
+    return true;
+}
+
+Response CurlNetworkAdapter::get(const std::string& url,
+                                 const std::map<std::string, std::string>& header,
+                                 const std::map<std::string, std::string>& proxies,
+                                 const std::map<std::string, ProxyAuthentication>& proxyAuthentications) {
+    Response response;
+    if (!curl) {
+        response.error = "CURL is not initialized.";
+        return response;
+    }
+
+    CURLcode res;
+    std::string headerString;
+
+    // Update header
+    struct curl_slist* headers = NULL;
+    for (const auto& it : header) {
+        headers = curl_slist_append(headers, (it.first + ": " + it.second).c_str());
+    }
+
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+
+    // Set the callback function to receive the response
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response.text);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &headerString);
+
+    // Proxy setup
+    const std::string protocol = url.substr(0, url.find(':'));
+    if (proxies.count(protocol) > 0) {
+        curl_easy_setopt(curl, CURLOPT_PROXY, proxies.at(protocol).c_str());
+        if (proxyAuthentications.count(protocol) > 0) {
+            curl_easy_setopt(curl, CURLOPT_PROXYUSERNAME, proxyAuthentications.at(protocol).user.c_str());
+            curl_easy_setopt(curl, CURLOPT_PROXYPASSWORD, proxyAuthentications.at(protocol).password.c_str());
+        }
+    }
+
+    // Perform the request
+    res = curl_easy_perform(curl);
+
+    if (res != CURLE_OK) {
+        response.error = curl_easy_strerror(res);
+        response.operationTimedOut = res == CURLE_OPERATION_TIMEDOUT;
+        return response;
+    }
+
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response.statusCode);
+
+    // Parse the headers from headerString
+    response.header = ParseHeader(headerString);
+
+    return response;
+}
+
+void CurlNetworkAdapter::close() {
+}
+
+CurlNetworkAdapter::~CurlNetworkAdapter() {
+    if (curl) {
+        curl_easy_cleanup(curl);
+    }
+}
+
+} // configcat
+
+#endif // CONFIGCAT_EXTERNAL_NETWORK_ADAPTER_ENABLED

--- a/src/curlnetworkadapter.cpp
+++ b/src/curlnetworkadapter.cpp
@@ -44,8 +44,8 @@ int ProgressCallback(void* clientp, curl_off_t dltotal, curl_off_t dlnow, curl_o
 }
 
 int CurlNetworkAdapter::ProgressFunction(curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
-    if (listener) {
-        return listener->isClosed() ? 1 : 0;  // Return 0 to continue, or 1 to abort
+    if (httpSessionObserver) {
+        return httpSessionObserver->isClosed() ? 1 : 0;  // Return 0 to continue, or 1 to abort
     }
 
     return 0;
@@ -81,8 +81,8 @@ std::map<std::string, std::string> ParseHeader(const std::string& headerString) 
     return header;
 }
 
-bool CurlNetworkAdapter::init(const HttpSessionAdapterListener* sessionAdapterListener, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) {
-    listener = sessionAdapterListener;
+bool CurlNetworkAdapter::init(const HttpSessionObserver* httpSessionObserver, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) {
+    this->httpSessionObserver = httpSessionObserver;
     libCurlResourceGuard = LibCurlResourceGuard::getInstance();
     curl = curl_easy_init();
     if (!curl) {

--- a/src/curlnetworkadapter.h
+++ b/src/curlnetworkadapter.h
@@ -15,7 +15,7 @@ public:
     CurlNetworkAdapter() = default;
     ~CurlNetworkAdapter();
 
-    bool init(const HttpSessionAdapterListener* sessionAdapterListener, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) override;
+    bool init(const HttpSessionObserver* httpSessionObserver, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) override;
     Response get(const std::string& url,
                  const std::map<std::string, std::string>& header,
                  const std::map<std::string, std::string>& proxies,
@@ -27,7 +27,7 @@ private:
     int ProgressFunction(curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
     friend int ProgressCallback(void* clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
 
-    const HttpSessionAdapterListener* listener = nullptr;
+    const HttpSessionObserver* httpSessionObserver = nullptr;
     std::shared_ptr<LibCurlResourceGuard> libCurlResourceGuard;
     CURL* curl = nullptr;
 };

--- a/src/curlnetworkadapter.h
+++ b/src/curlnetworkadapter.h
@@ -3,7 +3,9 @@
 #ifndef CONFIGCAT_EXTERNAL_NETWORK_ADAPTER_ENABLED
 
 #include "configcat/httpsessionadapter.h"
+#include <atomic>
 #include <curl/curl.h>
+#include <memory>
 
 
 namespace configcat {
@@ -15,7 +17,7 @@ public:
     CurlNetworkAdapter() = default;
     ~CurlNetworkAdapter();
 
-    bool init(const HttpSessionObserver* httpSessionObserver, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) override;
+    bool init(uint32_t connectTimeoutMs, uint32_t readTimeoutMs) override;
     Response get(const std::string& url,
                  const std::map<std::string, std::string>& header,
                  const std::map<std::string, std::string>& proxies,
@@ -27,9 +29,9 @@ private:
     int ProgressFunction(curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
     friend int ProgressCallback(void* clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
 
-    const HttpSessionObserver* httpSessionObserver = nullptr;
     std::shared_ptr<LibCurlResourceGuard> libCurlResourceGuard;
     CURL* curl = nullptr;
+    std::atomic<bool> closed = false;
 };
 
 } // configcat

--- a/src/curlnetworkadapter.h
+++ b/src/curlnetworkadapter.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifndef CONFIGCAT_EXTERNAL_NETWORK_ADAPTER_ENABLED
+
+#include "configcat/httpsessionadapter.h"
+#include <curl/curl.h>
+
+
+namespace configcat {
+
+class LibCurlResourceGuard;
+
+class CurlNetworkAdapter : public HttpSessionAdapter {
+public:
+    CurlNetworkAdapter() = default;
+    ~CurlNetworkAdapter();
+
+    bool init(const HttpSessionAdapterListener* sessionAdapterListener, uint32_t connectTimeoutMs, uint32_t readTimeoutMs) override;
+    Response get(const std::string& url,
+                 const std::map<std::string, std::string>& header,
+                 const std::map<std::string, std::string>& proxies,
+                 const std::map<std::string, ProxyAuthentication>& proxyAuthentications) override;
+    void close() override;
+
+private:
+    // CURL progress functions
+    int ProgressFunction(curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
+    friend int ProgressCallback(void* clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
+
+    const HttpSessionAdapterListener* listener = nullptr;
+    std::shared_ptr<LibCurlResourceGuard> libCurlResourceGuard;
+    CURL* curl = nullptr;
+};
+
+} // configcat
+
+#endif // CONFIGCAT_EXTERNAL_NETWORK_ADAPTER_ENABLED

--- a/test/mock.h
+++ b/test/mock.h
@@ -89,7 +89,7 @@ public:
         responses.push({response, delayInSeconds});
     }
 
-    bool init(const configcat::HttpSessionAdapterListener* sessionAdapterListener,
+    bool init(const configcat::HttpSessionObserver* httpSessionObserver,
               uint32_t connectTimeoutMs, uint32_t readTimeoutMs) override {
         return true;
     }

--- a/test/mock.h
+++ b/test/mock.h
@@ -89,7 +89,14 @@ public:
         responses.push({response, delayInSeconds});
     }
 
-    configcat::Response get(const std::string& url, const std::map<std::string, std::string>& header) override {
+    bool init(const configcat::HttpSessionAdapterListener* sessionAdapterListener,
+              uint32_t connectTimeoutMs, uint32_t readTimeoutMs) override {
+        return true;
+    }
+
+    configcat::Response get(const std::string& url, const std::map<std::string, std::string>& header,
+                            const std::map<std::string, std::string>& proxies,
+                            const std::map<std::string, configcat::ProxyAuthentication>& proxyAuthentications) override {
         requests.push_back({url, header});
 
         if (!responses.empty()) {

--- a/test/mock.h
+++ b/test/mock.h
@@ -89,8 +89,7 @@ public:
         responses.push({response, delayInSeconds});
     }
 
-    bool init(const configcat::HttpSessionObserver* httpSessionObserver,
-              uint32_t connectTimeoutMs, uint32_t readTimeoutMs) override {
+    bool init(uint32_t connectTimeoutMs, uint32_t readTimeoutMs) override {
         return true;
     }
 


### PR DESCRIPTION
### Describe the purpose of your pull request

- Introduced `CONFIGCAT_USE_EXTERNAL_NETWORK_ADAPTER` cmake option. If you turn it on, the cpp-sdk won't include the `libcurl` library. In this case, in the ConfigCat options you should add a custom http session adapter. ConfigCat will use this custom adapter for network requests.

### Related issues (only if applicable)

https://trello.com/c/X7CAz3B3/2871-unreal-sdk

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
