### PR TITLE
Fix client use after free issue

### DIFF
--- a/include/configcat/configcatclient.h
+++ b/include/configcat/configcatclient.h
@@ -121,6 +121,8 @@ private:
 
     ConfigCatClient(const std::string& sdkKey, const ConfigCatOptions& options);
 
+    void closeCore();
+
     template<typename ValueType>
     ValueType _getValue(const std::string& key, const ValueType& defaultValue, const std::shared_ptr<ConfigCatUser>& user = nullptr) const;
 

--- a/include/configcat/configcatclient.h
+++ b/include/configcat/configcatclient.h
@@ -23,11 +23,17 @@ struct SettingResult;
 
 class ConfigCatClient {
 public:
+    ConfigCatClient(const ConfigCatClient&) = delete; // Disable copy
+    ConfigCatClient& operator=(const ConfigCatClient&) = delete;
+
+    ConfigCatClient(ConfigCatClient&&) = delete; // Disable move
+    ConfigCatClient& operator=(ConfigCatClient&&) = delete;
+
     // Creates a new or gets an already existing [ConfigCatClient] for the given [sdkKey].
-    static ConfigCatClient* get(const std::string& sdkKey, const ConfigCatOptions* options = nullptr);
+    static std::shared_ptr<ConfigCatClient> get(const std::string& sdkKey, const ConfigCatOptions* options = nullptr);
 
     // Closes an individual [ConfigCatClient] instance.
-    static void close(ConfigCatClient* client);
+    static void close(const std::shared_ptr<ConfigCatClient>& client);
 
     // Closes all [ConfigCatClient] instances.
     static void closeAll();
@@ -111,6 +117,8 @@ public:
     inline std::shared_ptr<Hooks> getHooks() { return hooks; }
 
 private:
+    struct MakeSharedEnabler;
+
     ConfigCatClient(const std::string& sdkKey, const ConfigCatOptions& options);
 
     template<typename ValueType>
@@ -137,7 +145,7 @@ private:
     std::unique_ptr<ConfigService> configService;
 
     static std::mutex instancesMutex;
-    static std::unordered_map<std::string, std::unique_ptr<ConfigCatClient>> instances;
+    static std::unordered_map<std::string, std::shared_ptr<ConfigCatClient>> instances;
 };
 
 } // namespace configcat

--- a/include/configcat/configcatclient.h
+++ b/include/configcat/configcatclient.h
@@ -121,7 +121,7 @@ private:
 
     ConfigCatClient(const std::string& sdkKey, const ConfigCatOptions& options);
 
-    void closeCore();
+    void closeResources();
 
     template<typename ValueType>
     ValueType _getValue(const std::string& key, const ValueType& defaultValue, const std::shared_ptr<ConfigCatUser>& user = nullptr) const;

--- a/src/configcatclient.cpp
+++ b/src/configcatclient.cpp
@@ -70,7 +70,7 @@ void ConfigCatClient::close(const std::shared_ptr<ConfigCatClient>& client) {
     {
         lock_guard<mutex> lock(instancesMutex);
 
-        client->closeCore();
+        client->closeResources();
 
         for (auto it = instances.begin(); it != instances.end(); ++it) {
             if (it->second == client) {
@@ -88,7 +88,7 @@ void ConfigCatClient::closeAll() {
     lock_guard<mutex> lock(instancesMutex);
 
     for (const auto& [_, instance] : instances) {
-        instance->closeCore();
+        instance->closeResources();
     }
 
     instances.clear();
@@ -117,7 +117,7 @@ ConfigCatClient::ConfigCatClient(const std::string& sdkKey, const ConfigCatOptio
     }
 }
 
-void ConfigCatClient::closeCore() {
+void ConfigCatClient::closeResources() {
     configService.reset(); // stop polling by destroying configService
 }
 

--- a/test/test-specialcharacter.cpp
+++ b/test/test-specialcharacter.cpp
@@ -10,7 +10,7 @@ using MatrixData = vector<vector<string>>;
 
 class SpecialCharacterTest : public ::testing::Test {
 public:
-    ConfigCatClient* client = nullptr;
+    shared_ptr<ConfigCatClient> client = nullptr;
     void SetUp() override {
         client = ConfigCatClient::get("configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g");
     }

--- a/test/test-variationid.cpp
+++ b/test/test-variationid.cpp
@@ -85,7 +85,7 @@ public:
       }
     })";
 
-    ConfigCatClient* client = nullptr;
+    shared_ptr<ConfigCatClient> client = nullptr;
     shared_ptr<MockHttpSessionAdapter> mockHttpSessionAdapter = make_shared<MockHttpSessionAdapter>();
 
     void SetUp() override {


### PR DESCRIPTION
### Describe the purpose of your pull request

I suggest not returning a C pointer from `ConfigCatClient.get` because that can lead to use after free issues, demonstrated by [these tests](https://github.com/configcat/cpp-sdk/compare/config-v6...fix-client-use-after-free?expand=1#diff-188a76d2debaf98b111557064156ce97a87bfee61d75015123e082c7c4bc9e60R729-R775).

Also, let's disable the move constructor of `ConfigCatClient` because the SDK should manage client instances, we don't want to allow end users to take ownership of the client instances.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
