### PR TITLE
EvaluationDetailsBase - added virtual constructor (Warning C4265)

### DIFF
--- a/include/configcat/evaluationdetails.h
+++ b/include/configcat/evaluationdetails.h
@@ -47,6 +47,8 @@ protected:
         , matchedPercentageOption(matchedPercentageOption ? std::optional<PercentageOption>(*matchedPercentageOption) : std::nullopt)
     {}
 
+    virtual ~EvaluationDetailsBase() = default;
+
     virtual std::optional<Value> getValue() const = 0;
 };
 


### PR DESCRIPTION
### Describe the purpose of your pull request

- Fixed build issues when compiling and linking against Unreal Engine. Error: `Warning C4265 : 'configcat::EvaluationDetailsBase': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly`

### Related issues (only if applicable)

- [Unreal Engine SDK](https://github.com/configcat/unreal-engine-sdk)

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [X] I have executed the full automated test set against my changes.
- [X] I have validated my changes against all supported platform versions.
- [X] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
