### PR TITLE
Fix initial config load when auto poll enabled with results from cache

### DIFF
--- a/src/configentry.cpp
+++ b/src/configentry.cpp
@@ -30,9 +30,6 @@ shared_ptr<const ConfigEntry> ConfigEntry::fromString(const string& text) {
     }
 
     auto eTag = text.substr(fetchTimeIndex + 1, eTagIndex - fetchTimeIndex - 1);
-    if (eTag.empty()) {
-        throw invalid_argument("Empty eTag value");
-    }
 
     auto configJsonString = text.substr(eTagIndex + 1);
     try {

--- a/src/configservice.h
+++ b/src/configservice.h
@@ -40,7 +40,7 @@ public:
 
 private:
     // Returns the ConfigEntry object and error message in case of any error.
-    std::tuple<std::shared_ptr<const ConfigEntry>, std::optional<std::string>, std::exception_ptr> fetchIfOlder(double threshold, bool preferCache = false);
+    std::tuple<std::shared_ptr<const ConfigEntry>, std::optional<std::string>, std::exception_ptr> fetchIfOlder(double threshold, bool preferCached = false);
     void setInitialized();
     std::shared_ptr<const ConfigEntry> readCache();
     void writeCache(const std::shared_ptr<const ConfigEntry>& configEntry);

--- a/src/version.h
+++ b/src/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define CONFIGCAT_VERSION "4.0.0"
+#define CONFIGCAT_VERSION "4.0.1"


### PR DESCRIPTION
### Describe the purpose of your pull request

- Fix initial config JSON load when auto poll enabled with results from cache.
- Allow empty etag in the cache

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
